### PR TITLE
gears/stats.py: Add Take Cover action to Stealth skill.

### DIFF
--- a/gears/geffects.py
+++ b/gears/geffects.py
@@ -250,6 +250,10 @@ class AIAssistAnim( animobs.Caption ):
     DEFAULT_TEXT = 'AI Assisted!'
 
 
+class TakeCoverAnim( SmokePoof ):
+    # TODO: derive from animobs and then fill with its own animation.
+    pass
+
 
 class SmallBullet( animobs.ShotAnim ):
     DEFAULT_SPRITE_NAME = "anim_s_bullet.png"

--- a/gears/stats.py
+++ b/gears/stats.py
@@ -209,6 +209,28 @@ class Stealth( Skill ):
             targets=1)
         invodict[self].append(ba)
 
+        take_cover_skill = self
+        take_cover_stat = Speed
+        take_cover_bonus = min(max(pc.get_skill_score(take_cover_stat, take_cover_skill) * 2 - 50, 25), 100)
+        take_cover = pbge.effects.Invocation(
+            name = 'Take Cover',
+            fx = geffects.AddEnchantment(geffects.TakingCover,
+                     enchant_params = { 'percent_bonus': take_cover_bonus },
+                     anim = geffects.TakeCoverAnim),
+            area = pbge.scenes.targetarea.SelfOnly(),
+            ai_tar = aitargeters.GenericTargeter(
+                         targetable_types=(pbge.scenes.PlaceableThing,),
+                         conditions=[
+                             aitargeters.TargetIsOperational(),
+                             aitargeters.TargetIsAlly(),
+                             aitargeters.TargetDoesNotHaveEnchantment(geffects.TakingCover)]),
+            used_in_combat = True, used_in_exploration = True,
+            shot_anim = None,
+            data = geffects.AttackData(pbge.image.Image('sys_skillicons.png',32,32),3),
+            price = [geffects.MentalPrice(3),],
+            targets = 1)
+        invodict[self].append(take_cover)
+
 
 class Science( Skill ):
     name = 'Science'


### PR DESCRIPTION
The Take Cover / Spot Behind Cover might be how stealth and scouting interact in the future.

Closes: #35