### PR TITLE
gears/base.py: Can now remove all modules from a mecha without crashing the game.

### DIFF
--- a/gears/base.py
+++ b/gears/base.py
@@ -3020,6 +3020,12 @@ class Mecha(BaseGear, ContainerDamageHandler, Mover, VisibleGear, HasPower, Comb
         """
         mass_factor = (self.mass ** 2) // (10000 * self.scale.SIZE_FACTOR ** 6)
         engine_rating, has_gyro = self.get_engine_rating_and_gyro_status()
+        # It is possible for mass_factor to drop to 0
+        # if the mecha is massless, e.g. if all modules
+        # are removed.
+        # mass_factor is always a non-negative integer.
+        if mass_factor == 0:
+            mass_factor = 1
         # We now have the mass_factor, engine_rating, and has_gyro.
         it = engine_rating // mass_factor
         if not has_gyro:


### PR DESCRIPTION

For example you want to add/replace the head, and you have this
strange compulsion to make sure the head module comes first in
the sub_coms before the torso module or else you can't shake the
image that the mech's head is growing out of its ass.