### PR TITLE
Inform build of numpy headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 from Cython.Build import cythonize
+import numpy
 
 setup(  name='ghcaramel',
         version='0.100',
@@ -23,4 +24,5 @@ setup(  name='ghcaramel',
             'Pygame','numpy'
         ],
         ext_modules=cythonize("caramel-recolor-cython/pbgerecolor.pyx"),
+        include_dirs=[numpy.get_include()],
       )


### PR DESCRIPTION
When I try to build Gearhead Caramel on my Arch Linux system like this:

```
python setup.py build
```

I get the following error message:

```
caramel-recolor-cython/pbgerecolor.c:611:10: fatal error: numpy/arrayobject.h: No such file or directory
  611 | #include "numpy/arrayobject.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
error: command 'gcc' failed with exit status 1
```

This patch fixes that.