### PR TITLE
game/content/ghplots/missionbuilder.py: Properly set assistant in BAM_DefeatArmy.

### DIFF
--- a/game/content/ghplots/missionbuilder.py
+++ b/game/content/ghplots/missionbuilder.py
@@ -501,9 +501,10 @@ class BAM_DefeatArmy(Plot):
         if npc2:
             plotutility.CharacterMover(self, npc2, myscene, team2)
         else:
+            mek = gears.selector.generate_ace(self.rank, myfac, myscene.environment)
+            team2.contents.append(mek)
             npc2 = self.register_element("_assistant",
-                                         gears.selector.generate_ace(self.rank, myfac, myscene.environment),
-                                         dident="_eteam")
+                                         mek.get_pilot())
 
         self.obj = adventureseed.MissionObjective("Defeat {_commander} and {_assistant}".format(**self.elements),
                                                   MAIN_OBJECTIVE_VALUE * 3)


### PR DESCRIPTION
`gears.selector.generate_ace` returns a `gears.base.Mecha`, not a
`gears.base.Character`.

If we load the return value of `generate_ace` directly into the
`"_assistant"` element, then the objective will be named something
like "Defeat Amuro and Buru Buru", naming the mecha of the assistant
rather than the assistant zemself, which seems a bit rude.

The only other use of `generate_ace` in the same file also makes an
effort to extract the pilot and put it in the appropriate element.