### PR TITLE
pbge/scenes/__init__.py: Fix mmode attribute problems.

### DIFF
--- a/pbge/scenes/__init__.py
+++ b/pbge/scenes/__init__.py
@@ -321,7 +321,7 @@ class Scene( object ):
         else:
             return 0
     def model_altitude( self, m,x,y ):
-        if not hasattr(m,"mmode") or m.mmode.altitude is None:
+        if not hasattr(m,"mmode") or not m.mmode or m.mmode.altitude is None:
             return self.tile_altitude(x,y)
         else:
             return max(self._map[x][y].altitude(),m.mmode.altitude)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "main.py", line 271, in <module>
    play_the_game()
  File "main.py", line 262, in play_the_game
    action(tsrd)
  File "main.py", line 172, in load_game
    camp.play()
  File "/home/almkglor/games/gearhead-caramel/gears/__init__.py", line 435, in play
    super(GearHeadCampaign, self).play()
  File "/home/almkglor/games/gearhead-caramel/pbge/campaign.py", line 107, in play
    exp.go()
  File "/home/almkglor/games/gearhead-caramel/game/exploration.py", line 413, in go
    self.view()
  File "/home/almkglor/games/gearhead-caramel/pbge/scenes/viewer.py", line 358, in __call__
    if self.scene.model_altitude(m,*d_pos) >= 0:
  File "/home/almkglor/games/gearhead-caramel/pbge/scenes/__init__.py", line 324, in model_altitude
    if not hasattr(m,"mmode") or m.mmode.altitude is None:
AttributeError: 'NoneType' object has no attribute 'altitude'
```