### PR TITLE
gears/base.py: Make Combatant.get_primary_attack not crash if no library

### DIFF
--- a/gears/base.py
+++ b/gears/base.py
@@ -380,6 +380,8 @@ class Combatant(KeyObject):
 
     def get_primary_attack(self):
         mylibrary = self.get_attack_library()
+        if not mylibrary:
+            return None
         return max(mylibrary, key=lambda a: a.get_average_thrill_power(self, True))
 
     def get_skill_library(self, in_combat=False):


### PR DESCRIPTION
Fixes: #163 