### PR TITLE
gears/__init__.py: Fix disappearing half-cannibalized mechas bug.

### DIFF
--- a/gears/__init__.py
+++ b/gears/__init__.py
@@ -561,7 +561,7 @@ class GearHeadCampaign(pbge.campaign.Campaign):
                         pc.restore_all()
                         if announce:
                             pbge.alert("{} has been severely injured and is removed to a safe place.".format(pc))
-                elif random.randint(1,100) <= skill or not pbge.util.config.getboolean("DIFFICULTY","mecha_can_die"):
+                elif random.randint(1,100) <= skill or not pbge.util.config.getboolean("DIFFICULTY","mecha_can_die") or pc not in self.scene.contents:
                     self.party.append(pc)
 
     def remove_party_from_scene(self):


### PR DESCRIPTION
Fixes: #126

We used to have a spurious problem where a half-cannibalized mecha
with torso and/or engines missing would *sometimes* disappear from
your party list whenever you moved between scenes.

Turns it only happened sometimes because we were treating it as a
combat-destroyed mecha, and the repair roll would kick in, sometimes
saving the mecha, sometimes failing the repair roll and losing the
mecha.

Fix by only destroying mecha on the map.