### PR TITLE
game/invoker.py: Fix bug where we mistakenly give odds for dead mecha if another mecha is standing on top of it.

### DIFF
--- a/game/invoker.py
+++ b/game/invoker.py
@@ -297,6 +297,8 @@ class InvocationUI(object):
         pbge.my_state.view.overlays.clear()
         pbge.my_state.view.overlays[self.pc.pos] = (self.cursor_sprite, self.SC_ORIGIN)
         mmecha = pbge.my_state.view.modelmap.get(pbge.my_state.view.mouse_tile)
+        if mmecha:
+            mmecha = [m for m in mmecha if m.is_operational()]
         if self.invo and pbge.my_state.view.mouse_tile in self.legal_tiles:
             aoe = self.invo.area.get_area(self.camp, self.pc.pos, pbge.my_state.view.mouse_tile)
             for p in aoe:


### PR DESCRIPTION
Fixes: #28

![Screenshot from 2020-09-04 20-27-11](https://user-images.githubusercontent.com/3140/92239393-838df580-eeed-11ea-9260-56003e70fdb7.png)
