### PR TITLE
design/Phoenix.txt: Actually give the L-Cannon EMP.

### DIFF
--- a/design/Phoenix.txt
+++ b/design/Phoenix.txt
@@ -71,7 +71,7 @@ Mecha
                                     name = "L-Cannon Clip (EMP)"
                                     ammo_type=SelfPropelled_130mm
                                     quantity=20
-                                    attributes = (Haywire)
+                                    attributes = (HaywireAttack,)
                             END
                     END
                 HoverJets


### PR DESCRIPTION
No wonder my playtesting in #181 had this lower than the Phoenix cannon.  The L-Cannon doesn't actually have Haywire!