### PR TITLE
gears/attackattributes.py: Rescale ChargeAttack for the new damage scaling

### DIFF
--- a/gears/attackattributes.py
+++ b/gears/attackattributes.py
@@ -159,7 +159,7 @@ class ChargeAttack(Singleton):
     def get_attacks( self, weapon ):
         aa = weapon.get_basic_attack(name='Charge',attack_icon=15)
         aa.fx.modifiers.append(geffects.GenericBonus('Charge',10))
-        aa.fx.children[0].damage_d = 10
+        aa.fx.children[0].damage_d = round(aa.fx.children[0].damage_d * 5 / 3)
         aa.area = geffects.DashTarget(weapon.get_root())
         aa.data.thrill_power = int(aa.data.thrill_power * 1.5)
         aa.shot_anim = geffects.DashFactory(weapon.get_root())

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,5 @@
+- Nerf Charge Attack, which was incorrectly not rescaled during the previous health and damage scale adjustment in 0.542.
+
 v0.551 October 20 2020
 - Added auto_save default to data/config_defaults.cfg
 - Reduced Corsair's heavy rocket pod to 4 rockets, but bigger ones


### PR DESCRIPTION
Looks like the main reason why Charge *still* seems overpowered is because
when we rescaled damage vs. health, we forgot to rescale Charge as well.
We only rescaled `get_basic_attack` for all attacking gears, but
`attackattributes.ChargeAttack` overrides the raw value instead of basing
on the raw value.

Prior to this change, Charge meant more than 2.5x the normal damage, a
massive bonus compared to the +2/3 damage that Charge did prior to the
rescale.

With this change, Charge adds +75% more damage, and should adapt to future
damage rescalings as well, targeting +2/3 damage.